### PR TITLE
Fixing warning after upgrading tagger to use CUDAExecutionprovider instead of CPUExecutionprovider in attempt to improve performance speed. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-onnxruntime
+onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/


### PR DESCRIPTION
Please see https://github.com/pythongosssss/ComfyUI-WD14-Tagger/issues/62

This pull request seeks help in fixing the following message after upgrading to use CUDAExecutionprovider instead of CPUExecutionprovider.

[W:onnxruntime:, transformer_memcpy.cc:74 ApplyImpl] 12 Memcpy nodes are added to the graph main_graph for CUDAExecutionProvider. It might have negative impact on performance (including unable to run CUDA graph). Set session_options.log_severity_level=1 to see the detail logs before this message.

Warning seems to indicate a bottleneck caused by GPU/CPU data transfer by memcpy.