### PR TITLE
Update wd14tagger.py download_model to use proxy

### DIFF
--- a/wd14tagger.py
+++ b/wd14tagger.py
@@ -117,7 +117,7 @@ async def download_model(model, client_id, node):
     url = config["models"][model]
     url = url.replace("{HF_ENDPOINT}", hf_endpoint)
     url = f"{url}/resolve/main/"
-    async with aiohttp.ClientSession(loop=asyncio.get_event_loop()) as session:
+    async with aiohttp.ClientSession(loop=asyncio.get_event_loop(), trust_env=True) as session:
         async def update_callback(perc):
             nonlocal client_id
             message = ""


### PR DESCRIPTION
Unlike requests, aiohttp won't read environment variables like `HTTP_PROXY` by default, set `trust_env` to `True` will make it use proxy if available, which may help to resolve some network-related issues like #66 #61 #58