### PR TITLE
split node WD14Tagger|pysssss 

### DIFF
--- a/wd14tagger.py
+++ b/wd14tagger.py
@@ -245,6 +245,7 @@ class WD14TaggerOnly:
         }}
 
     RETURN_TYPES = ("STRING",)
+    OUTPUT_IS_LIST = (True,)
     FUNCTION = "tag"
 
     CATEGORY = "image"


### PR DESCRIPTION
split `WD14Tagger|pysssss` into `WD14ModelLoader|pysssss` and `WD14TaggerOnly|pysssss` to use comfyui cache and reduce tag run cost

* WD14ModelLoader|pysssss cache  onnx infer session and avoid  load model every time
* WD14TaggerOnly|pysssss just do inference