### PR TITLE
feat: support use system proxy

### DIFF
--- a/pysssss.py
+++ b/pysssss.py
@@ -175,7 +175,7 @@ async def download_to_file(url, destination, update_callback, is_ext_subpath=Tru
     if is_ext_subpath:
         destination = get_ext_dir(destination)
     try:
-        async with session.get(url) as response:
+        async with session.get(url, proxy=os.getenv('http_proxy')) as response:
             size = int(response.headers.get('content-length', 0)) or None
 
             with tqdm(


### PR DESCRIPTION
Some network maybe throw error:

`Connection timeout to host https://huggingface.co/SmilingWolf/wd-vit-tagger-v3/resolve/main/model.onnx`

So I support proxy for model downloading, now it will read the env proxy to use.